### PR TITLE
pin torch to cuda11.3 version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,4 @@
 # These version constraints come from Zendar's internal libraries that
 # require this package, just to reduce the chance of version
 # inconsistencies.
-requires = ["torch>=1.13.1, <2.0", "tqdm", "numpy"]
+requires = ["torch==1.11.0+cu113", "tqdm", "numpy", "setuptools"]


### PR DESCRIPTION
This PR pins pytorch to a version built against `cuda 11.3`.

On some of our workstations (which run `cuda 11.2`), the `torchsparse` build fails when relying on `torch 1.13.1` (which was built against `cuda 11.7`), because of the minor-version mis-match.  However, it seems like `torch 1.11 + cu11.3` works ok (since the version mis-match is smaller).

All of this is a work-around, until such time as the whole company can upgrade cuda away from 11.2.